### PR TITLE
Snapshot uses latest released version

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheck.scala
+++ b/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheck.scala
@@ -21,7 +21,7 @@ object MimaVersionCheck extends AutoPlugin {
       major: Int,
       minor: Int,
       patch: Int,
-      snapshotUsesLatestReleasedVersion: Boolean
+      isSnapshotOfLatestReleasedVersion: Boolean
   ): Set[(Int, Int, Int)] = {
     val majorVersions: List[Int] =
       if (major == 0 && minor == 0) List.empty[Int] // If 0.0.x do not check MiMa
@@ -33,7 +33,7 @@ object MimaVersionCheck extends AutoPlugin {
       if (minor == 0 && patch == 0) List.empty[Int]
       else if (currentMinVersion != minor) List(0)
       else {
-        val maxPatchValue = if (snapshotUsesLatestReleasedVersion) patch else patch - 1
+        val maxPatchValue = if (isSnapshotOfLatestReleasedVersion) patch else patch - 1
         Range(0, maxPatchValue).inclusive.toList
       }
 
@@ -45,14 +45,14 @@ object MimaVersionCheck extends AutoPlugin {
     versions.toSet
   }
 
-  def mimaVersions(version: String, snapshotUsesLatestReleasedVersion: Boolean): Set[String] =
+  def mimaVersions(version: String, isSnapshotOfLatestReleasedVersion: Boolean): Set[String] =
     VersionNumber(version) match {
-      case VersionNumber(Seq(major, minor, patch, _*), _, extras) =>
+      case VersionNumber(Seq(major, minor, patch, _*), _, _) =>
         semverBinCompatVersions(
           major.toInt,
           minor.toInt,
           patch.toInt,
-          extras.exists(_.endsWith("-SNAPSHOT")) && snapshotUsesLatestReleasedVersion
+          isSnapshotOfLatestReleasedVersion
         ).map { case (maj, min, pat) => maj.toString + "." + min.toString + "." + pat.toString }
       case _ =>
         Set.empty[String]
@@ -64,22 +64,36 @@ object MimaVersionCheck extends AutoPlugin {
     mimaVersionCheckSnapshotUsesLatestReleasedVersion := false,
   )
 
-  override def projectSettings: Seq[Def.Setting[_]] = List(
-    mimaFailOnNoPrevious := false,
-    mimaFailOnProblem :=
-      mimaVersions(version.value, mimaVersionCheckSnapshotUsesLatestReleasedVersion.value).toList.nonEmpty,
-    mimaPreviousArtifacts :=
-      (mimaVersions(version.value, mimaVersionCheckSnapshotUsesLatestReleasedVersion.value) ++
-        mimaVersionCheckExtraVersions.value)
-        .diff(mimaVersionCheckExcludedVersions.value)
-        .map { v =>
-          val moduleN = if (sbtPlugin.value) {
-            moduleName.value + "_" + scalaBinaryVersion.value.toString + "_" + sbtBinaryVersion.value.toString
-          } else {
-            moduleName.value + "_" + scalaBinaryVersion.value.toString
+  override def projectSettings: Seq[Def.Setting[_]] = {
+    List(
+      mimaFailOnNoPrevious := false,
+      mimaFailOnProblem := mimaVersions(
+        version.value,
+        isSnapshot.value && mimaVersionCheckSnapshotUsesLatestReleasedVersion.value
+      ).toList.nonEmpty,
+      mimaPreviousArtifacts := {
+        val fullVersionSet =
+          (mimaVersions(
+            version.value,
+            isSnapshot.value && mimaVersionCheckSnapshotUsesLatestReleasedVersion.value
+          ) ++ mimaVersionCheckExtraVersions.value)
+            .diff(mimaVersionCheckExcludedVersions.value)
+        val msg =
+          if (fullVersionSet.nonEmpty)
+            s"Checking against versions ${fullVersionSet.toList.sorted.mkString(", ")}"
+          else "No versions to check"
+        sLog.value.info(s"MiMa: ${moduleName.value} - $msg")
+        fullVersionSet
+          .map { v =>
+            val moduleN = if (sbtPlugin.value) {
+              moduleName.value + "_" + scalaBinaryVersion.value + "_" + sbtBinaryVersion.value
+            } else {
+              moduleName.value + "_" + scalaBinaryVersion.value
+            }
+            organization.value % moduleN % v
           }
-          organization.value % moduleN % v
-        }
-  )
+      }
+    )
+  }
 
 }

--- a/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheck.scala
+++ b/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheck.scala
@@ -16,18 +16,26 @@ object MimaVersionCheck extends AutoPlugin {
 
   override def requires =
     MimaPlugin
-  
-  def semverBinCompatVersions(major: Int, minor: Int, patch: Int): Set[(Int, Int, Int)] = {
+
+  def semverBinCompatVersions(
+      major: Int,
+      minor: Int,
+      patch: Int,
+      snapshotUsesLatestReleasedVersion: Boolean
+  ): Set[(Int, Int, Int)] = {
     val majorVersions: List[Int] =
       if (major == 0 && minor == 0) List.empty[Int] // If 0.0.x do not check MiMa
       else List(major)
-    val minorVersions : List[Int] =
+    val minorVersions: List[Int] =
       if (major >= 1) Range(0, minor).inclusive.toList
       else List(minor)
-    def patchVersions(currentMinVersion: Int): List[Int] = 
+    def patchVersions(currentMinVersion: Int): List[Int] =
       if (minor == 0 && patch == 0) List.empty[Int]
       else if (currentMinVersion != minor) List(0)
-      else Range(0, patch - 1).inclusive.toList
+      else {
+        val maxPatchValue = if (snapshotUsesLatestReleasedVersion) patch else patch - 1
+        Range(0, maxPatchValue).inclusive.toList
+      }
 
     val versions = for {
       maj <- majorVersions
@@ -36,33 +44,42 @@ object MimaVersionCheck extends AutoPlugin {
     } yield (maj, min, pat)
     versions.toSet
   }
-  
-  def mimaVersions(version: String): Set[String] = VersionNumber(version) match {
-    case VersionNumber(Seq(major, minor, patch, _*), _, _) =>
-      semverBinCompatVersions(major.toInt, minor.toInt, patch.toInt)
-        .map{case (maj, min, pat) => maj.toString + "." + min.toString + "." + pat.toString}
-    case _ =>
-      Set.empty[String]
-  }
+
+  def mimaVersions(version: String, snapshotUsesLatestReleasedVersion: Boolean): Set[String] =
+    VersionNumber(version) match {
+      case VersionNumber(Seq(major, minor, patch, _*), _, extras) =>
+        semverBinCompatVersions(
+          major.toInt,
+          minor.toInt,
+          patch.toInt,
+          extras.exists(_.endsWith("-SNAPSHOT")) && snapshotUsesLatestReleasedVersion
+        ).map { case (maj, min, pat) => maj.toString + "." + min.toString + "." + pat.toString }
+      case _ =>
+        Set.empty[String]
+    }
 
   override def globalSettings: Seq[Def.Setting[_]] = List(
     mimaVersionCheckExtraVersions := Set(),
-    mimaVersionCheckExcludedVersions := Set()
+    mimaVersionCheckExcludedVersions := Set(),
+    mimaVersionCheckSnapshotUsesLatestReleasedVersion := false,
   )
-  
+
   override def projectSettings: Seq[Def.Setting[_]] = List(
     mimaFailOnNoPrevious := false,
-    mimaFailOnProblem := mimaVersions(version.value).toList.headOption.isDefined,
-    mimaPreviousArtifacts := (mimaVersions(version.value) ++ mimaVersionCheckExtraVersions.value)
-      .filterNot(mimaVersionCheckExcludedVersions.value.contains(_))
-      .map{v => 
-        val moduleN = if (sbtPlugin.value){
-          moduleName.value + "_" + scalaBinaryVersion.value.toString + "_" + sbtBinaryVersion.value.toString
-        } else {
-          moduleName.value + "_" + scalaBinaryVersion.value.toString
+    mimaFailOnProblem :=
+      mimaVersions(version.value, mimaVersionCheckSnapshotUsesLatestReleasedVersion.value).toList.nonEmpty,
+    mimaPreviousArtifacts :=
+      (mimaVersions(version.value, mimaVersionCheckSnapshotUsesLatestReleasedVersion.value) ++
+        mimaVersionCheckExtraVersions.value)
+        .diff(mimaVersionCheckExcludedVersions.value)
+        .map { v =>
+          val moduleN = if (sbtPlugin.value) {
+            moduleName.value + "_" + scalaBinaryVersion.value.toString + "_" + sbtBinaryVersion.value.toString
+          } else {
+            moduleName.value + "_" + scalaBinaryVersion.value.toString
+          }
+          organization.value % moduleN % v
         }
-        organization.value % moduleN % v
-      }
   )
 
 }

--- a/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheckKeys.scala
+++ b/core/src/main/scala/io/chrisdavenport/sbtmimaversioncheck/MimaVersionCheckKeys.scala
@@ -9,4 +9,7 @@ class MimaVersionCheckKeys {
     settingKey[Set[String]]("Extra Versions to check Mima compatibility for")
   final val mimaVersionCheckExcludedVersions =
     settingKey[Set[String]]("Versions Normally checked for to exclude from Mima checks")
+  final val mimaVersionCheckSnapshotUsesLatestReleasedVersion =
+    settingKey[Boolean](
+      "Snapshots are based on the latest release version number, rather than the next (unreleased) version number")
 }

--- a/core/src/sbt-test/sbt-mima-version-check/simple/build.sbt
+++ b/core/src/sbt-test/sbt-mima-version-check/simple/build.sbt
@@ -97,6 +97,33 @@ lazy val majorMinorPatch = project.in(file("majorMinorPatch"))
     }
   )
 
+lazy val majorMinorPatchSnapshot = project.in(file("majorMinorPatchSnapshot"))
+  .settings(
+    version := "3.0.2-SNAPSHOT",
+
+    TaskKey[Unit]("check") := {
+      val expected: Set[String] = Set(
+        "3.0.0",
+        "3.0.1"
+      )
+      testVersion(version.value, expected, mimaPreviousArtifacts.value)
+    }
+  )
+
+lazy val majorMinorPatchSnapshotUsesLatestReleasedVersion = project.in(file("majorMinorPatchSnapshotUsesLatestReleasedVersion"))
+  .settings(
+    version := "3.0.1+65-4fb25ad8+20201219-1448-SNAPSHOT",
+    mimaVersionCheckSnapshotUsesLatestReleasedVersion := true,
+
+    TaskKey[Unit]("check") := {
+      val expected: Set[String] = Set(
+        "3.0.0",
+        "3.0.1"
+      )
+      testVersion(version.value, expected, mimaPreviousArtifacts.value)
+    }
+  )
+
 lazy val sbtPluginModuleName = project.in(file("sbtPluginModule"))
   .settings(
     version := "2.2.3",

--- a/core/src/sbt-test/sbt-mima-version-check/simple/test
+++ b/core/src/sbt-test/sbt-mima-version-check/simple/test
@@ -7,6 +7,8 @@
 > majorZeroPatch/check
 > majorMinorZero/check
 > majorMinorPatch/check
+> majorMinorPatchSnapshot/check
+> majorMinorPatchSnapshotUsesLatestReleasedVersion/check
 
 > sbtPluginModuleName/check
 > normalProjectModuleName/check


### PR DESCRIPTION
Hey @ChristopherDavenport - great plugin! It's great not having to explicitly set the version/s to check against.

The project I'm working on (fs2-rabbit) generates snapshots using the most recently released version number as the base. In our case the most recent release is `3.0.1`, and an example snapshot version is `3.0.1+65-4fb25ad8+20201219-1448-SNAPSHOT`.

This PR adds a new `Setting[Boolean]` named `mimaVersionCheckSnapshotUsesLatestReleasedVersion` which is defaulted to `false` (and means the plugin is backward compatible). When set to `true` it means our example snapshot above will also check back-compat against `3.0.1`. 

** `mimaVersionCheckSnapshotUsesLatestReleasedVersion` is also a strong contender for _Longest SBT Variable Name_ 😆. Happy to hear alternatives.